### PR TITLE
Fix rain timer resetting every time people sleep

### DIFF
--- a/src/main/java/net/quetzi/morpheus/helpers/SleepChecker.java
+++ b/src/main/java/net/quetzi/morpheus/helpers/SleepChecker.java
@@ -75,7 +75,9 @@ public class SleepChecker {
             Morpheus.playerSleepStatus.get(world.provider.getDimensionId()).wakeAllPlayers();
             alertSent.put(world.provider.getDimensionId(), true);
         }
-        world.provider.resetRainAndThunder();
+        if(world.getWorldInfo().isRaining() || world.getWorldInfo().isThundering()) {
+            world.provider.resetRainAndThunder();
+        }
     }
 
     private boolean areEnoughPlayersAsleep(int dimension) {


### PR DESCRIPTION
Only reset rain and thunder timer if it was raining when skipping the night, otherwise the chance for rain will be drastically reduced as a new rain time is calculated (see World.updateWeatherBody()), which is a minimum of 10 minutes at 20 TPS but can be up to 150 minutes, which is impossible to reach as Minecraft days aren't that long and people are likely to have slept through the night at that point, starting the same thing all over.

With this fix, the rain timer will only be reset if it actually was raining when skipping the night, which means rain will still stop if it was raining, but not be prevented for the next x minutes if it wasn't raining before.