### PR TITLE
Make it possible to set spawnpoint during daytime

### DIFF
--- a/src/main/java/net/quetzi/morpheus/Morpheus.java
+++ b/src/main/java/net/quetzi/morpheus/Morpheus.java
@@ -30,6 +30,7 @@ public class Morpheus {
     private static boolean  alertEnabled;
     public static  boolean  includeMiners;
     public static  int      groundLevel;
+    public static  boolean  setSpawnDaytime;
     public static Configuration config;
 
     @Instance(References.MODID)
@@ -61,6 +62,7 @@ public class Morpheus {
         onMorningText = config.get("settings", "OnMorningText", "Wakey, wakey, rise and shine... Good Morning everyone!").getString();
         includeMiners = config.get("settings", "IncludeMiners", true).getBoolean();
         groundLevel = config.getInt("settings", "GroundLevel", 64, 1, 255, "Ground Level (1-255)");
+        setSpawnDaytime = config.get("settings", "AllowSetSpanwDaytime", true).getBoolean();
         config.save();
 
     }

--- a/src/main/java/net/quetzi/morpheus/helpers/MorpheusEventHandler.java
+++ b/src/main/java/net/quetzi/morpheus/helpers/MorpheusEventHandler.java
@@ -76,23 +76,25 @@ public class MorpheusEventHandler {
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void bedClicked(PlayerInteractEvent.RightClickBlock event) {
 
-        if (!event.getWorld().isRemote && event.getWorld().isDaytime()) {
-            BlockPos pos = event.getPos();
-            IBlockState state = event.getWorld().getBlockState(pos);
-            if (state.getBlock() instanceof BlockBed) {
-                if (state.getValue(BlockBed.PART) != BlockBed.EnumPartType.HEAD) {
-                    pos = event.getPos().offset(state.getValue(BlockBed.FACING));
-                    state = event.getWorld().getBlockState(pos);
-                    if (!(state.getBlock() instanceof BlockBed) || state.getValue(BlockBed.PART) != BlockBed.EnumPartType.HEAD) {
-                        return;
+        if (Morpheus.setSpawnDaytime) {
+            if (! event.getWorld().isRemote && event.getWorld().isDaytime()) {
+                BlockPos pos = event.getPos();
+                IBlockState state = event.getWorld().getBlockState(pos);
+                if (state.getBlock() instanceof BlockBed) {
+                    if (state.getValue(BlockBed.PART) != BlockBed.EnumPartType.HEAD) {
+                        pos = event.getPos().offset(state.getValue(BlockBed.FACING));
+                        state = event.getWorld().getBlockState(pos);
+                        if (! (state.getBlock() instanceof BlockBed) || state.getValue(BlockBed.PART) != BlockBed.EnumPartType.HEAD) {
+                            return;
+                        }
                     }
-                }
-                if (event.getWorld().provider.canRespawnHere() && event.getWorld().provider.getBiomeForCoords(pos) != Biomes.HELL) {
-                    if (!state.getValue(BlockBed.OCCUPIED)) {
-                        event.getEntityPlayer().setSpawnPoint(event.getEntityPlayer().getPosition(), false);
-                        event.getEntityPlayer().setSpawnChunk(pos, false, event.getWorld().provider.getDimension());
-                        event.getEntityPlayer().addChatComponentMessage(new TextComponentString(References.SPAWN_SET));
-                        event.setCanceled(true);
+                    if (event.getWorld().provider.canRespawnHere() && event.getWorld().provider.getBiomeForCoords(pos) != Biomes.HELL) {
+                        if (! state.getValue(BlockBed.OCCUPIED)) {
+                            event.getEntityPlayer().setSpawnPoint(event.getEntityPlayer().getPosition(), false);
+                            event.getEntityPlayer().setSpawnChunk(pos, false, event.getWorld().provider.getDimension());
+                            event.getEntityPlayer().addChatComponentMessage(new TextComponentString(References.SPAWN_SET));
+                            event.setCanceled(true);
+                        }
                     }
                 }
             }

--- a/src/main/java/net/quetzi/morpheus/helpers/MorpheusEventHandler.java
+++ b/src/main/java/net/quetzi/morpheus/helpers/MorpheusEventHandler.java
@@ -1,5 +1,7 @@
 package net.quetzi.morpheus.helpers;
 
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerChangedDimensionEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
@@ -8,6 +10,12 @@ import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.WorldTickEvent;
 import net.quetzi.morpheus.Morpheus;
 import net.quetzi.morpheus.world.WorldSleepState;
+
+import net.minecraft.block.BlockBed;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Biomes;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextComponentString;
 
 public class MorpheusEventHandler {
 
@@ -60,6 +68,32 @@ public class MorpheusEventHandler {
                     Morpheus.checker.updatePlayerStates(event.world);
                 } else {
                     Morpheus.playerSleepStatus.remove(event.world.provider.getDimension());
+                }
+            }
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public void bedClicked(PlayerInteractEvent.RightClickBlock event) {
+
+        if (!event.getWorld().isRemote && event.getWorld().isDaytime()) {
+            BlockPos pos = event.getPos();
+            IBlockState state = event.getWorld().getBlockState(pos);
+            if (state.getBlock() instanceof BlockBed) {
+                if (state.getValue(BlockBed.PART) != BlockBed.EnumPartType.HEAD) {
+                    pos = event.getPos().offset(state.getValue(BlockBed.FACING));
+                    state = event.getWorld().getBlockState(pos);
+                    if (!(state.getBlock() instanceof BlockBed) || state.getValue(BlockBed.PART) != BlockBed.EnumPartType.HEAD) {
+                        return;
+                    }
+                }
+                if (event.getWorld().provider.canRespawnHere() && event.getWorld().provider.getBiomeForCoords(pos) != Biomes.HELL) {
+                    if (!state.getValue(BlockBed.OCCUPIED)) {
+                        event.getEntityPlayer().setSpawnPoint(event.getEntityPlayer().getPosition(), false);
+                        event.getEntityPlayer().setSpawnChunk(pos, false, event.getWorld().provider.getDimension());
+                        event.getEntityPlayer().addChatComponentMessage(new TextComponentString(References.SPAWN_SET));
+                        event.setCanceled(true);
+                    }
                 }
             }
         }

--- a/src/main/java/net/quetzi/morpheus/helpers/References.java
+++ b/src/main/java/net/quetzi/morpheus/helpers/References.java
@@ -19,4 +19,6 @@ public class References {
     public static final String XMASTEXT       = "Good morning everyone! HAPPY CHRISTMAS!";
     public static final String STPATRICKSTEXT = "Good morning everyone! HAPPY ST PATRICKS DAY!";
     public static final String HALLOWEENTEXT  = "Good morning everyone! HAPPY SAMHAIN!";
+
+    public static final String SPAWN_SET      = "New spawnpoint has been set!";
 }


### PR DESCRIPTION
This PR makes it possible to set your spawnpoint during daytime. As this mods skips nighttime at a current percentage, it might be hard for everyone to set their spawn in a bed when you have a crowded server. This simply resolves that issue by allowing people to set their spawn point by simply right clicking the bed (only during daytime).