### PR TITLE
Make narrator not say "six" when reading the bedtime messages.

### DIFF
--- a/src/main/java/net/quetzi/morpheus/helpers/DateHandler.java
+++ b/src/main/java/net/quetzi/morpheus/helpers/DateHandler.java
@@ -1,5 +1,8 @@
 package net.quetzi.morpheus.helpers;
 
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.Style;
+import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.quetzi.morpheus.Morpheus;
 
@@ -12,20 +15,22 @@ public class DateHandler
 {
     public enum Event
     {
-        XMAS(25, 12, TextFormatting.RED + References.XMASTEXT),
-        NEW_YEAR(1, 1, TextFormatting.GOLD + References.NEWYEARTEXT),
-        STPATRICKS(17, 3, TextFormatting.DARK_GREEN + References.STPATRICKSTEXT),
-        HALLOWEEN(31, 10, TextFormatting.DARK_PURPLE + References.HALLOWEENTEXT),
-        NONE(0, 0, TextFormatting.GOLD + Morpheus.onMorningText);
+        XMAS(25, 12, new Style().setColor(TextFormatting.RED), References.XMASTEXT),
+        NEW_YEAR(1, 1, new Style().setColor(TextFormatting.GOLD), References.NEWYEARTEXT),
+        STPATRICKS(17, 3, new Style().setColor(TextFormatting.DARK_GREEN), References.STPATRICKSTEXT),
+        HALLOWEEN(31, 10, new Style().setColor(TextFormatting.DARK_PURPLE), References.HALLOWEENTEXT),
+        NONE(0, 0, new Style().setColor(TextFormatting.GOLD), Morpheus.onMorningText);
 
         private final int    month;
         private final int    day;
+        private final Style  style;
         private final String text;
 
-        Event(int day, int month, String text)
+        Event(int day, int month, Style style, String text)
         {
             this.month = month;
             this.day = day;
+            this.style = style;
             this.text = text;
         }
 
@@ -47,8 +52,9 @@ public class DateHandler
         return Event.NONE;
     }
 
-    public static String getMorningText()
+    public static ITextComponent getMorningTextComponent()
     {
-        return getEvent(Calendar.getInstance()).text;
+        DateHandler.Event event = getEvent(Calendar.getInstance());
+        return new TextComponentString(event.text).setStyle(event.style);
     }
 }

--- a/src/main/java/net/quetzi/morpheus/helpers/SleepChecker.java
+++ b/src/main/java/net/quetzi/morpheus/helpers/SleepChecker.java
@@ -1,6 +1,8 @@
 package net.quetzi.morpheus.helpers;
 
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
@@ -53,7 +55,7 @@ public class SleepChecker
         }
     }
 
-    private void alertPlayers(TextComponentString alert, World world)
+    private void alertPlayers(ITextComponent alert, World world)
     {
         if ((alert != null) && (Morpheus.isAlertEnabled()))
         {
@@ -64,10 +66,15 @@ public class SleepChecker
         }
     }
 
-    private TextComponentString createAlert(int dimension, String username, String text)
+    private ITextComponent createAlert(int dimension, String username, String text)
     {
         Morpheus.mLog.info(String.format("%s %s %s", username, text, Morpheus.playerSleepStatus.get(dimension).toString()));
-        return new TextComponentString(String.format("%s%s%s %s %s", TextFormatting.WHITE, username, TextFormatting.GOLD, text, Morpheus.playerSleepStatus.get(dimension).toString()));
+        ITextComponent toSend = new TextComponentString(username).setStyle(new Style().setColor(TextFormatting.WHITE))
+                .appendSibling(new TextComponentString(" "))
+                .appendSibling(new TextComponentString(text).setStyle(new Style().setColor(TextFormatting.GOLD)))
+                .appendSibling(new TextComponentString(" "))
+                .appendSibling(new TextComponentString(Morpheus.playerSleepStatus.get(dimension).toString()));
+        return toSend;
     }
 
     private void advanceToMorning(World world)
@@ -83,7 +90,7 @@ public class SleepChecker
         if (!alertSent.get(world.provider.getDimension()))
         {
             // Send Good morning message
-            alertPlayers(new TextComponentString(DateHandler.getMorningText()), world);
+            alertPlayers(DateHandler.getMorningTextComponent(), world);
             Morpheus.playerSleepStatus.get(world.provider.getDimension()).wakeAllPlayers();
             alertSent.put(world.provider.getDimension(), true);
         }


### PR DESCRIPTION
When using Morpheus, and the player has the Minecraft narrator active (Options -> Chat Settings -> Narrator), if a Morpheus message appears, then the narrator will read the number from the color code. This patch makes the formatting happen by setting a Style to the TextComponentString, rather than the raw color code character with the color code identifier, and as such, not read by the narrator.