### PR TITLE
Fixed commands so it only shows commands that the player can run

### DIFF
--- a/src/main/java/net/quetzi/morpheus/commands/CommandMorpheus.java
+++ b/src/main/java/net/quetzi/morpheus/commands/CommandMorpheus.java
@@ -13,7 +13,11 @@ public class CommandMorpheus {
     public static void register(CommandDispatcher<CommandSource> cmdDisp) {
         LiteralArgumentBuilder<CommandSource> morpheusCommand = Commands.literal("morpheus");
         morpheusCommand.executes((command) -> {
-            command.getSource().sendFeedback(new StringTextComponent("Usage: " + References.USAGE), true);
+            if(command.getSource().hasPermissionLevel(2)) {
+                command.getSource().sendFeedback(new StringTextComponent("Usage: " + References.USAGE), true);
+            }else {
+                command.getSource().sendFeedback(new StringTextComponent("Usage: " + References.USAGE_NOT_OP), true);
+            }
             return 1;
         });
         morpheusCommand
@@ -24,6 +28,7 @@ public class CommandMorpheus {
                 }));
         morpheusCommand
                 .then(Commands.literal("alert")
+                .requires(commandSource -> commandSource.hasPermissionLevel(2))
                 .executes((command) -> {
                     if (Config.SERVER.alertEnabled.get()) {
                         Config.SERVER.alertEnabled.set(false);
@@ -36,14 +41,13 @@ public class CommandMorpheus {
                 }));
         morpheusCommand
                 .then(Commands.literal("percent")
+                .requires(commandSource -> commandSource.hasPermissionLevel(2))
                 .then(Commands.argument("value", IntegerArgumentType.integer(0,100))
                 .executes((command) -> {
-                    if (command.getSource().hasPermissionLevel(2)) {
-                        int newPercent = IntegerArgumentType.getInteger(command, "value");
-                        Config.SERVER.perc.set(newPercent);
-                        Config.SERVER.perc.save();
-                        command.getSource().sendFeedback(new StringTextComponent("Sleep vote percentage set to " + Config.SERVER.perc.get() + "%"), true);
-                    }
+                    int newPercent = IntegerArgumentType.getInteger(command, "value");
+                    Config.SERVER.perc.set(newPercent);
+                    Config.SERVER.perc.save();
+                    command.getSource().sendFeedback(new StringTextComponent("Sleep vote percentage set to " + Config.SERVER.perc.get() + "%"), true);
                     return 1;
                 })));
 //        morpheusCommand

--- a/src/main/java/net/quetzi/morpheus/helpers/References.java
+++ b/src/main/java/net/quetzi/morpheus/helpers/References.java
@@ -14,6 +14,7 @@ public class References {
     public static final String PERCENT_USAGE = "Usage: /morpheus percent <percentage>";
     public static final String DISABLE_USAGE = "Usage: /morpheus disable <dimension number>";
     public static final String USAGE = "/morpheus <alert : version> | /morpheus percent <percentage> | /morpheus disable <dimension number>";
+    public static final String USAGE_NOT_OP = "/morpheus version";
 
     public static final String NEWYEARTEXT = "Good morning everyone! HAPPY NEW YEAR!";
     public static final String XMASTEXT = "Good morning everyone! HAPPY CHRISTMAS!";


### PR DESCRIPTION
Simply pull request to make it so that players cant see the subcommand while tab completing that they don't have permissions to run